### PR TITLE
refactor(server): 优化控制器方法拦截器的依赖注入方式

### DIFF
--- a/wind-server/src/main/java/com/wind/server/configuration/WindServerAutoConfiguration.java
+++ b/wind-server/src/main/java/com/wind/server/configuration/WindServerAutoConfiguration.java
@@ -11,6 +11,7 @@ import com.wind.server.web.exception.RestfulErrorAttributes;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.aspectj.AspectJExpressionPointcut;
 import org.springframework.aop.support.DefaultBeanFactoryPointcutAdvisor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -84,15 +85,9 @@ public class WindServerAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty(prefix = CONTROLLER_METHOD_ASPECT_NAME, name = ENABLED_NAME, havingValue = TRUE, matchIfMissing = true)
-    public WindControllerMethodInterceptor windControllerMethodInterceptor(ApplicationContext context,
+    public WindControllerMethodInterceptor windControllerMethodInterceptor(ObjectProvider<ScriptAuditLogRecorder> recorderProvider,
                                                                            Collection<MethodParameterInjector> injectors) {
-        ScriptAuditLogRecorder recorder = null;
-        try {
-            recorder = context.getBean(ScriptAuditLogRecorder.class);
-        } catch (NestedRuntimeException exception) {
-            log.info("un enable audit log");
-        }
-        return new WindControllerMethodInterceptor(recorder, MethodParameterInjector.composite(injectors));
+        return new WindControllerMethodInterceptor(recorderProvider.getIfAvailable(), MethodParameterInjector.composite(injectors));
     }
 
     @Bean


### PR DESCRIPTION
- 使用 ObjectProvider 替代直接从 ApplicationContext 获取 bean
- 移除异常捕获逻辑，改用 getIfAvailable() 方法安全获取可选依赖
- 简化了 ScriptAuditLogRecorder 的注入流程